### PR TITLE
Fix: Improve run_service.sh reliability and deployment handling

### DIFF
--- a/run_service.sh
+++ b/run_service.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 
-rm -r mech
+# Stop and remove potentially orphaned containers from previous runs
+echo "Stopping potentially orphaned mech containers..."
+docker stop $(docker ps -q --filter "name=mech.*_abci_0") 2>/dev/null || true
+docker stop $(docker ps -q --filter "name=mech.*_tm_0") 2>/dev/null || true
+echo "Removing potentially orphaned mech containers..."
+docker rm $(docker ps -aq --filter "name=mech.*_abci_0") 2>/dev/null || true
+docker rm $(docker ps -aq --filter "name=mech.*_tm_0") 2>/dev/null || true
+
+# Remove previous mech directory (contains build artifacts, not running containers)
+echo "Removing previous mech directory..."
+rm -rf mech
 
 # Load env vars
 set -o allexport; source .1env; set +o allexport
@@ -19,6 +29,15 @@ autonomy push-all
 
 autonomy fetch --local --service valory/mech && cd mech
 
+# Clean up previous docker-compose environment if it exists
+previous_build_dir=$(find . -maxdepth 1 -type d -name 'abci_build_*' -print -quit)
+if [ -n "$previous_build_dir" ]; then
+    echo "Found previous build directory: $previous_build_dir. Cleaning up..."
+    (cd "$previous_build_dir" && docker-compose down --remove-orphans) || echo "docker-compose down failed, continuing..."
+    echo "Removing previous build directory: $previous_build_dir"
+    rm -rf "$previous_build_dir"
+fi
+
 # Build the image
 autonomy build-image
 
@@ -27,5 +46,16 @@ cp $PWD/../keys.json .
 
 autonomy deploy build -ltm --n ${NUM_AGENTS:-4}
 
-# Run the deployment
-autonomy deploy run --build-dir abci_build/
+# Find the build directory (assumes only one matching directory exists)
+build_dir=$(find . -maxdepth 1 -type d -name 'abci_build_*' -print -quit)
+
+# Check if build_dir was found
+if [ -z "$build_dir" ]; then
+    echo "Failed to find build directory starting with abci_build_ in $(pwd)"
+    exit 1
+fi
+
+echo "Found deployment build directory: $build_dir"
+
+# Run the deployment using the found build directory
+autonomy deploy run --build-dir "$build_dir"


### PR DESCRIPTION
## Proposed changes

- Adds pre-run cleanup steps using `docker stop` and `docker rm` to handle orphaned containers from previous runs, preventing port allocation errors.
- Modifies the script to dynamically find the `abci_build_*` directory created by `autonomy deploy build` instead of using a hardcoded path. This ensures the `autonomy deploy run` command targets the correct deployment directory.

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [x] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works